### PR TITLE
Prevent tiles from bottom row from going to negative spaces if row selected too quickly.

### DIFF
--- a/frontend/src/components/player_board/player_board.js
+++ b/frontend/src/components/player_board/player_board.js
@@ -123,7 +123,7 @@ class PlayerBoard extends Component {
           key={i}
           onClick={() => {
             if (this.activeComponent() && this.context.selectedColor) {
-              if (confirm('are you sure you want to place your tiles in the negative spaces?')) {
+              if (window.confirm('are you sure you want to place your tiles in the negative spaces?')) {
                 this.context.makeMove('negative')
               }
             }

--- a/frontend/src/components/player_board/player_board.js
+++ b/frontend/src/components/player_board/player_board.js
@@ -123,7 +123,9 @@ class PlayerBoard extends Component {
           key={i}
           onClick={() => {
             if (this.activeComponent() && this.context.selectedColor) {
-              this.context.makeMove('negative')
+              if (confirm('are you sure you want to place your tiles in the negative spaces?')) {
+                this.context.makeMove('negative')
+              }
             }
           }}
           className={styles.NegativeSpace}>


### PR DESCRIPTION
I added a confirmation pop-up to guard the player in case this situation occurs.